### PR TITLE
Fix GitHub Actions build timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
     - name: Set up Java
-      uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # tag=v4.7.1
       with:
         java-version: "21"
         distribution: "temurin"
@@ -42,9 +42,9 @@ jobs:
     - test
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
     - name: Set up Java
-      uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # tag=v4.7.1
       with:
         java-version: "21"
         distribution: "temurin"
@@ -52,14 +52,14 @@ jobs:
     - name: Build
       run: mvn -B --no-transfer-progress clean package -DskipTests
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3.3.0
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # tag=v3.6.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3.8.0
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # tag=v3.10.0
       id: buildx
       with:
         install: true
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3.3.0
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # tag=v3.4.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -70,7 +70,7 @@ jobs:
         # Repository must name must be lowercase.
         echo "repo=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
     - name: Build and Push Container Image
-      uses: docker/build-push-action@v6.12.0
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # tag=v6.18.0
       with:
         tags: ghcr.io/${{ steps.determine-container-repo.outputs.repo }}:snapshot
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
As per https://github.com/orgs/community/discussions/160793#discussioncomment-13312469

Also bumps all actions to their latest versions, and fixes incorrect tag annotations.